### PR TITLE
feat: Web API コントローラーと DTO の実装

### DIFF
--- a/MemoApp.API/Controllers/MemosController.cs
+++ b/MemoApp.API/Controllers/MemosController.cs
@@ -1,0 +1,217 @@
+using Microsoft.AspNetCore.Mvc;
+using MemoApp.API.DTOs;
+using MemoApp.Core.Entities;
+using MemoApp.Core.Interfaces;
+
+namespace MemoApp.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class MemosController : ControllerBase
+{
+    private readonly IMemoRepository _memoRepository;
+    private readonly ITagRepository _tagRepository;
+
+    public MemosController(IMemoRepository memoRepository, ITagRepository tagRepository)
+    {
+        _memoRepository = memoRepository;
+        _tagRepository = tagRepository;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<ApiResponse<IEnumerable<MemoDto>>>> GetMemos()
+    {
+        try
+        {
+            var memos = await _memoRepository.GetAllAsync();
+            var memoDtos = memos.Select(MapToDto).ToList();
+            return Ok(ApiResponse<IEnumerable<MemoDto>>.SuccessResult(memoDtos, "メモ一覧を取得しました"));
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, ApiResponse<IEnumerable<MemoDto>>.ErrorResult($"メモ取得中にエラーが発生しました: {ex.Message}"));
+        }
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<ApiResponse<MemoDto>>> GetMemo(int id)
+    {
+        try
+        {
+            var memo = await _memoRepository.GetByIdAsync(id);
+            if (memo == null)
+            {
+                return NotFound(ApiResponse<MemoDto>.ErrorResult("指定されたメモが見つかりません"));
+            }
+
+            var memoDto = MapToDto(memo);
+            return Ok(ApiResponse<MemoDto>.SuccessResult(memoDto, "メモを取得しました"));
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, ApiResponse<MemoDto>.ErrorResult($"メモ取得中にエラーが発生しました: {ex.Message}"));
+        }
+    }
+
+    [HttpGet("search")]
+    public async Task<ActionResult<ApiResponse<IEnumerable<MemoDto>>>> SearchMemos([FromQuery] string query)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                return BadRequest(ApiResponse<IEnumerable<MemoDto>>.ErrorResult("検索クエリが必要です"));
+            }
+
+            var memos = await _memoRepository.SearchAsync(query);
+            var memoDtos = memos.Select(MapToDto).ToList();
+            return Ok(ApiResponse<IEnumerable<MemoDto>>.SuccessResult(memoDtos, $"検索結果: {memoDtos.Count}件のメモが見つかりました"));
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, ApiResponse<IEnumerable<MemoDto>>.ErrorResult($"メモ検索中にエラーが発生しました: {ex.Message}"));
+        }
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<ApiResponse<MemoDto>>> CreateMemo([FromBody] CreateMemoDto createMemoDto)
+    {
+        try
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ApiResponse<MemoDto>.ErrorResult("入力データが無効です"));
+            }
+
+            var memo = await MapToEntity(createMemoDto);
+            var createdMemo = await _memoRepository.AddAsync(memo);
+            var memoDto = MapToDto(createdMemo);
+            
+            return CreatedAtAction(nameof(GetMemo), new { id = memoDto.Id }, 
+                ApiResponse<MemoDto>.SuccessResult(memoDto, "メモを作成しました"));
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, ApiResponse<MemoDto>.ErrorResult($"メモ作成中にエラーが発生しました: {ex.Message}"));
+        }
+    }
+
+    [HttpPut("{id}")]
+    public async Task<ActionResult<ApiResponse<MemoDto>>> UpdateMemo(int id, [FromBody] UpdateMemoDto updateMemoDto)
+    {
+        try
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ApiResponse<MemoDto>.ErrorResult("入力データが無効です"));
+            }
+
+            var existingMemo = await _memoRepository.GetByIdAsync(id);
+            if (existingMemo == null)
+            {
+                return NotFound(ApiResponse<MemoDto>.ErrorResult("指定されたメモが見つかりません"));
+            }
+
+            var memo = await MapToEntity(updateMemoDto);
+            memo.Id = id;
+            memo.CreatedAt = existingMemo.CreatedAt;
+            
+            var updatedMemo = await _memoRepository.UpdateAsync(memo);
+            var memoDto = MapToDto(updatedMemo);
+            
+            return Ok(ApiResponse<MemoDto>.SuccessResult(memoDto, "メモを更新しました"));
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, ApiResponse<MemoDto>.ErrorResult($"メモ更新中にエラーが発生しました: {ex.Message}"));
+        }
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<ActionResult<ApiResponse<object>>> DeleteMemo(int id)
+    {
+        try
+        {
+            var memo = await _memoRepository.GetByIdAsync(id);
+            if (memo == null)
+            {
+                return NotFound(ApiResponse<object>.ErrorResult("指定されたメモが見つかりません"));
+            }
+
+            await _memoRepository.DeleteAsync(id);
+            return Ok(ApiResponse<object>.SuccessResult(new { }, "メモを削除しました"));
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, ApiResponse<object>.ErrorResult($"メモ削除中にエラーが発生しました: {ex.Message}"));
+        }
+    }
+
+    private static MemoDto MapToDto(Memo memo)
+    {
+        return new MemoDto
+        {
+            Id = memo.Id,
+            Title = memo.Title,
+            Content = memo.Content,
+            CreatedAt = memo.CreatedAt,
+            UpdatedAt = memo.UpdatedAt,
+            Tags = memo.Tags.Select(t => new TagDto 
+            { 
+                Id = t.Id, 
+                Name = t.Name,
+                MemoCount = t.Memos.Count
+            }).ToList()
+        };
+    }
+
+    private async Task<Memo> MapToEntity(CreateMemoDto createMemoDto)
+    {
+        var memo = new Memo
+        {
+            Title = createMemoDto.Title,
+            Content = createMemoDto.Content,
+            Tags = new List<Tag>()
+        };
+
+        foreach (var tagName in createMemoDto.Tags)
+        {
+            var existingTag = await _tagRepository.GetByNameAsync(tagName);
+            if (existingTag != null)
+            {
+                memo.Tags.Add(existingTag);
+            }
+            else
+            {
+                memo.Tags.Add(new Tag { Name = tagName });
+            }
+        }
+
+        return memo;
+    }
+
+    private async Task<Memo> MapToEntity(UpdateMemoDto updateMemoDto)
+    {
+        var memo = new Memo
+        {
+            Title = updateMemoDto.Title,
+            Content = updateMemoDto.Content,
+            Tags = new List<Tag>()
+        };
+
+        foreach (var tagName in updateMemoDto.Tags)
+        {
+            var existingTag = await _tagRepository.GetByNameAsync(tagName);
+            if (existingTag != null)
+            {
+                memo.Tags.Add(existingTag);
+            }
+            else
+            {
+                memo.Tags.Add(new Tag { Name = tagName });
+            }
+        }
+
+        return memo;
+    }
+}

--- a/MemoApp.API/Controllers/TagsController.cs
+++ b/MemoApp.API/Controllers/TagsController.cs
@@ -1,0 +1,97 @@
+using Microsoft.AspNetCore.Mvc;
+using MemoApp.API.DTOs;
+using MemoApp.Core.Entities;
+using MemoApp.Core.Interfaces;
+
+namespace MemoApp.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class TagsController : ControllerBase
+{
+    private readonly ITagRepository _tagRepository;
+
+    public TagsController(ITagRepository tagRepository)
+    {
+        _tagRepository = tagRepository;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<ApiResponse<IEnumerable<TagDto>>>> GetTags()
+    {
+        try
+        {
+            var tags = await _tagRepository.GetAllAsync();
+            var tagDtos = tags.Select(MapToDto).ToList();
+            return Ok(ApiResponse<IEnumerable<TagDto>>.SuccessResult(tagDtos, "タグ一覧を取得しました"));
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, ApiResponse<IEnumerable<TagDto>>.ErrorResult($"タグ取得中にエラーが発生しました: {ex.Message}"));
+        }
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<ApiResponse<TagDto>>> CreateTag([FromBody] CreateTagDto createTagDto)
+    {
+        try
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ApiResponse<TagDto>.ErrorResult("入力データが無効です"));
+            }
+
+            var existingTag = await _tagRepository.GetByNameAsync(createTagDto.Name);
+            if (existingTag != null)
+            {
+                return Conflict(ApiResponse<TagDto>.ErrorResult("同名のタグが既に存在します"));
+            }
+
+            var tag = new Tag { Name = createTagDto.Name };
+            var createdTag = await _tagRepository.AddAsync(tag);
+            var tagDto = MapToDto(createdTag);
+            
+            return CreatedAtAction(nameof(GetTags), new { id = tagDto.Id }, 
+                ApiResponse<TagDto>.SuccessResult(tagDto, "タグを作成しました"));
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, ApiResponse<TagDto>.ErrorResult($"タグ作成中にエラーが発生しました: {ex.Message}"));
+        }
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<ActionResult<ApiResponse<object>>> DeleteTag(int id)
+    {
+        try
+        {
+            var tag = await _tagRepository.GetByIdAsync(id);
+            if (tag == null)
+            {
+                return NotFound(ApiResponse<object>.ErrorResult("指定されたタグが見つかりません"));
+            }
+
+            if (tag.Memos.Any())
+            {
+                return BadRequest(ApiResponse<object>.ErrorResult("関連するメモがあるため、タグを削除できません"));
+            }
+
+            await _tagRepository.DeleteAsync(id);
+            return Ok(ApiResponse<object>.SuccessResult(new { }, "タグを削除しました"));
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, ApiResponse<object>.ErrorResult($"タグ削除中にエラーが発生しました: {ex.Message}"));
+        }
+    }
+
+    private static TagDto MapToDto(Tag tag)
+    {
+        return new TagDto
+        {
+            Id = tag.Id,
+            Name = tag.Name,
+            MemoCount = tag.Memos.Count
+        };
+    }
+}

--- a/MemoApp.API/DTOs/ApiResponse.cs
+++ b/MemoApp.API/DTOs/ApiResponse.cs
@@ -1,0 +1,28 @@
+namespace MemoApp.API.DTOs;
+
+public class ApiResponse<T>
+{
+    public bool Success { get; set; }
+    public T? Data { get; set; }
+    public string Message { get; set; } = string.Empty;
+
+    public static ApiResponse<T> SuccessResult(T data, string message = "")
+    {
+        return new ApiResponse<T>
+        {
+            Success = true,
+            Data = data,
+            Message = message
+        };
+    }
+
+    public static ApiResponse<T> ErrorResult(string message)
+    {
+        return new ApiResponse<T>
+        {
+            Success = false,
+            Data = default,
+            Message = message
+        };
+    }
+}

--- a/MemoApp.API/DTOs/MemoDto.cs
+++ b/MemoApp.API/DTOs/MemoDto.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace MemoApp.API.DTOs;
+
+public class MemoDto
+{
+    public int Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public List<TagDto> Tags { get; set; } = new();
+}
+
+public class CreateMemoDto
+{
+    [Required]
+    [StringLength(200)]
+    public string Title { get; set; } = string.Empty;
+    
+    [Required]
+    public string Content { get; set; } = string.Empty;
+    
+    public List<string> Tags { get; set; } = new();
+}
+
+public class UpdateMemoDto
+{
+    [Required]
+    [StringLength(200)]
+    public string Title { get; set; } = string.Empty;
+    
+    [Required]
+    public string Content { get; set; } = string.Empty;
+    
+    public List<string> Tags { get; set; } = new();
+}

--- a/MemoApp.API/DTOs/TagDto.cs
+++ b/MemoApp.API/DTOs/TagDto.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace MemoApp.API.DTOs;
+
+public class TagDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int MemoCount { get; set; }
+}
+
+public class CreateTagDto
+{
+    [Required]
+    [StringLength(50)]
+    public string Name { get; set; } = string.Empty;
+}


### PR DESCRIPTION
## Summary
- 統一されたレスポンス形式（ApiResponse<T>）を定義
- MemosController と TagsController を実装し、REST API エンドポイントを完備
- 適切なエラーハンドリング、バリデーション、HTTP ステータスコード対応
- Entity-DTO 間のマッピング機能を実装

## Changes
### DTO クラス
- **ApiResponse<T>**: 統一レスポンス形式（success, data, message）
- **MemoDto**: メモ表示用・CreateMemoDto/UpdateMemoDto（入力用）
- **TagDto**: タグ表示用・CreateTagDto（入力用）

### API エンドポイント
#### MemosController (`/api/memos`)
- `GET /` - メモ一覧取得（タグ付き、作成日時順）
- `GET /{id}` - メモ詳細取得
- `GET /search?query={searchTerm}` - メモ検索（Title, Content, Tags）
- `POST /` - メモ作成（タグ自動関連付け）
- `PUT /{id}` - メモ更新（タグ更新対応）
- `DELETE /{id}` - メモ削除

#### TagsController (`/api/tags`)
- `GET /` - タグ一覧取得（メモ数付き、名前順）
- `POST /` - タグ作成（重複チェック）
- `DELETE /{id}` - タグ削除（関連メモチェック）

### 技術的特徴
- モデルバインディング・バリデーション（Required, StringLength）
- 統一エラーハンドリング（try-catch, 適切なステータスコード）
- Entity-DTO マッピング（既存タグ検索・関連付け）
- 日本語メッセージ対応

## Test plan
- [x] ソリューション全体のビルド成功（警告0件）
- [x] コントローラー依存関係解決確認
- [x] DTO バリデーション属性確認

🤖 Generated with [Claude Code](https://claude.ai/code)